### PR TITLE
Setup package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>self_drive</name>
+  <version>0.1.0</version>
+  <description>control turtle's velocity based on its position</description>
+  <author email="sbdyr025@sch.ac.kr">LHJ_and_LJE</author>
+  <maintainer email="sbdyr025@sch.ac.kr">LHJ_and_LJE</maintainer>
+  <license>MIT License</license>
+
+  <depend>rclpy</depend>
+  <depend>turtlesim</depend>
+  <depend>geometry_msgs</depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+from setuptools import setup, find_packages
+
+package_name = 'self_drive'
+
+setup(
+    name=package_name,
+    version='0.1.0',
+    packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    author='LHJ, LJE',
+    author_email='sbdyr025@sch.ac.kr',
+    maintainer='LHJ, LJE',
+    maintainer_email='sbdyr025@sch.ac.kr',
+    keywords=['ROS'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: MIT License',
+        'Programming Language :: Python'
+    ],
+    description='turtlebot3 self drive controller',
+    license='MIT License',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            f'self_drive = {package_name}.self_drive:main',
+        ],
+    },
+)


### PR DESCRIPTION
wall follow를 실행하기 위한 setup.py와 packages.xml을 구현하는 브랜치입니다.
소스 코드를 setup.py와 package.xml에 정리하여 올립니다.
setup.py와 package.xml에 author와 maintainer를 변경하였습니다.
또한 엔트리 포인트에 self_drive를 추가하였습니다.
추가할 점 있으면 리뷰부탁드립니다
